### PR TITLE
Fix MCP and Gradio startup and centralize logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Log files
+logs/*
+!logs/.gitkeep

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -20,7 +20,7 @@ def extract_text(file_path: str) -> str:
         return pytesseract.image_to_string(img, lang='rus')
 
 
-async def chat_fn(message: str, file: Optional[str]):
+async def chat_fn(message: str, history: list, file: Optional[str]):
     text = message
     if file:
         text += "\n" + extract_text(file)
@@ -31,7 +31,11 @@ async def chat_fn(message: str, file: Optional[str]):
 def main():
     with gr.Blocks() as demo:
         gr.Markdown("# Ассистент бухгалтера")
-        chatbot = gr.ChatInterface(chat_fn, additional_inputs=[gr.File(label='Документ')])
+        chatbot = gr.ChatInterface(
+            chat_fn,
+            additional_inputs=[gr.File(label='Документ')],
+            type="messages",
+        )
     demo.launch(server_name="0.0.0.0")
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3,7 +3,7 @@ import logging
 from typing import Annotated, List, Dict, Any, Optional
 
 import httpx
-from fastapi import HTTPException, Request
+from fastapi import HTTPException
 from pydantic import Field
 from mcp.server.fastmcp import FastMCP
 from onec_client import (
@@ -106,9 +106,8 @@ async def get_item(type: str, name: str, id: str) -> Dict:
 
 @mcp.tool()
 @mcp.custom_route("/mcp/{type}/{name}", methods=["POST"])
-async def create_item(request: Request, type: str, name: str) -> Dict:
+async def create_item(type: str, name: str, payload: Dict[str, Any]) -> Dict:
     """Создать новый объект."""
-    payload = await request.json()
     if API_BASE_URL:
         return await _forward("POST", f"/{type}/{name}", json=payload)
     obj_store = _dummy_db.setdefault(f"{type}/{name}", {})
@@ -121,9 +120,8 @@ async def create_item(request: Request, type: str, name: str) -> Dict:
 
 @mcp.tool()
 @mcp.custom_route("/mcp/{type}/{name}/{id}", methods=["PATCH"])
-async def update_item(request: Request, type: str, name: str, id: str) -> Dict:
+async def update_item(type: str, name: str, id: str, payload: Dict[str, Any]) -> Dict:
     """Обновить существующий объект."""
-    payload = await request.json()
     if API_BASE_URL:
         return await _forward("PATCH", f"/{type}/{name}/{id}", json=payload)
     store = _dummy_db.setdefault(f"{type}/{name}", {})

--- a/start_MCP.sh
+++ b/start_MCP.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
+LOG_DIR="$(dirname "$0")/logs"
+mkdir -p "$LOG_DIR"
+
 echo "=== Запуск MCP-сервера на порту 9000 ==="
-nohup uvicorn mcp_server:mcp --host 0.0.0.0 --port 9000 > mcp_server.log 2>&1 &
+nohup uvicorn mcp_server:mcp --host 0.0.0.0 --port 9000 > "$LOG_DIR/mcp_server.log" 2>&1 &
 MCP_PID=$!
 echo "MCP-сервер запущен, PID=$MCP_PID"
 
 sleep 2
 
 echo "=== Запуск веб-интерфейса Gradio ==="
-nohup python gradio_app.py > gradio.log 2>&1 &
+nohup python gradio_app.py > "$LOG_DIR/gradio.log" 2>&1 &
 GRADIO_PID=$!
 echo "Gradio запущен, PID=$GRADIO_PID"
 

--- a/vLLM/start_vllm.sh
+++ b/vLLM/start_vllm.sh
@@ -1,5 +1,8 @@
 MODEL="Salesforce/xLAM-2-32b-fc-r"
+LOG_DIR="$(dirname "$0")/../logs"
+mkdir -p "$LOG_DIR"
 nohup vllm serve "$MODEL" \
   --enable-auto-tool-choice \
   --tool-call-parser xlam \
-  --tensor-parallel-size 2 &
+  --tensor-parallel-size 2 \
+  > "$LOG_DIR/vllm.log" 2>&1 &


### PR DESCRIPTION
## Summary
- refactor MCP create/update handlers to avoid pydantic schema issues
- align Gradio chat function with new API and enable messages format
- centralize all application logs under `logs/`

## Testing
- `python -m py_compile mcp_server.py gradio_app.py`
- `bash start_MCP.sh`
- `bash vLLM/start_vllm.sh`


------
https://chatgpt.com/codex/tasks/task_e_688dfff60f348328ae2d4e4d57b13444