### PR TITLE
Fix FastMCP server startup

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -31,6 +31,7 @@ ONEC_PASSWORD = os.getenv("ONEC_PASSWORD")
 logger = logging.getLogger(__name__)
 
 mcp = FastMCP("mcp_1c")
+app = mcp.streamable_http_app
 
 # --- Dummy storage for local testing ---
 _dummy_db: Dict[str, Dict[str, Dict]] = {}

--- a/start_MCP.sh
+++ b/start_MCP.sh
@@ -3,7 +3,7 @@ LOG_DIR="$(dirname "$0")/logs"
 mkdir -p "$LOG_DIR"
 
 echo "=== Запуск MCP-сервера на порту 9000 ==="
-nohup uvicorn mcp_server:mcp --host 0.0.0.0 --port 9000 > "$LOG_DIR/mcp_server.log" 2>&1 &
+nohup uvicorn mcp_server:app --host 0.0.0.0 --port 9000 > "$LOG_DIR/mcp_server.log" 2>&1 &
 MCP_PID=$!
 echo "MCP-сервер запущен, PID=$MCP_PID"
 


### PR DESCRIPTION
## Summary
- expose FastMCP ASGI application to uvicorn
- update launch script to target ASGI app correctly

## Testing
- `bash -n start_MCP.sh`
- `python -m py_compile mcp_server.py orchestrator.py gradio_app.py`
- `uvicorn mcp_server:app --host 127.0.0.1 --port 9000 & PID=$!`
- `curl -I http://127.0.0.1:9000/`
- `kill $PID`


------
https://chatgpt.com/codex/tasks/task_e_688e060146908328985435df0a095ce2