### PR TITLE
Improve startup scripts and chat history

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -1,6 +1,6 @@
 import os
 import asyncio
-from typing import Optional
+from typing import Optional, List, Tuple
 
 import gradio as gr
 from PIL import Image
@@ -24,8 +24,14 @@ async def chat_fn(message: str, history: list, file: Optional[str]):
     text = message
     if file:
         text += "\n" + extract_text(file)
+
+    formatted_history: List[dict] = []
+    for user_msg, bot_msg in history:
+        formatted_history.append({"role": "user", "content": user_msg})
+        formatted_history.append({"role": "assistant", "content": bot_msg})
+
     async with SearchAgent(mcp_cmd=os.getenv('MCP_URL', 'http://localhost:9000')) as agent:
-        return await agent.ask(text)
+        return await agent.ask(text, history=formatted_history)
 
 
 def main():
@@ -36,7 +42,7 @@ def main():
             additional_inputs=[gr.File(label='Документ')],
             type="messages",
         )
-    demo.launch(server_name="0.0.0.0")
+    demo.launch(server_name="0.0.0.0", server_port=7860)
 
 
 if __name__ == '__main__':

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -5,6 +5,7 @@ SearchAgent объединяет vLLM-чат и MCP-поиск.
         answer = await bot.ask("Привет, мир!")
 """
 import json, asyncio
+from typing import List, Dict
 from openai import AsyncOpenAI
 from fastmcp import Client as MCP
 
@@ -43,11 +44,18 @@ class SearchAgent:
         await self.mcp.__aexit__(*exc)
         await self.llm.__aexit__(*exc)
 
-    async def ask(self, prompt: str, system: str | None = None) -> str:
+    async def ask(
+            self,
+            prompt: str,
+            system: str | None = None,
+            history: List[Dict[str, str]] | None = None,
+    ) -> str:
         """Отправляет один запрос LLM, автоматически обслуживая tool-calls."""
-        msgs = []
+        msgs: List[Dict[str, str]] = []
         if system:
             msgs.append({"role": "system", "content": system})
+        if history:
+            msgs.extend(history)
         msgs.append({"role": "user", "content": prompt})
 
         while True:

--- a/start_MCP.sh
+++ b/start_MCP.sh
@@ -1,17 +1,35 @@
 #!/bin/bash
+set -e
+
 LOG_DIR="$(dirname "$0")/logs"
 mkdir -p "$LOG_DIR"
 
+# Stop previous instances to avoid port conflicts
+pkill -f "uvicorn mcp_server:app" 2>/dev/null || true
+pkill -f "gradio_app.py" 2>/dev/null || true
+pkill -f "vllm serve" 2>/dev/null || true
+
+MODEL=${MODEL:-Salesforce/xLAM-2-32b-fc-r}
+
+echo "=== Запуск vLLM на порту 8000 ==="
+nohup vllm serve "$MODEL" \
+  --port 8000 \
+  --enable-auto-tool-choice \
+  --tool-call-parser xlam \
+  --tensor-parallel-size 2 \
+  > "$LOG_DIR/vllm.log" 2>&1 &
+VLLM_PID=$!
+
+sleep 5
+
 echo "=== Запуск MCP-сервера на порту 9000 ==="
-nohup uvicorn mcp_server:app --host 0.0.0.0 --port 9000 > "$LOG_DIR/mcp_server.log" 2>&1 &
+nohup uvicorn mcp_server:app --factory --host 0.0.0.0 --port 9000 \
+  > "$LOG_DIR/mcp_server.log" 2>&1 &
 MCP_PID=$!
-echo "MCP-сервер запущен, PID=$MCP_PID"
 
-sleep 2
-
-echo "=== Запуск веб-интерфейса Gradio ==="
+echo "=== Запуск веб-интерфейса Gradio на порту 7860 ==="
 nohup python gradio_app.py > "$LOG_DIR/gradio.log" 2>&1 &
 GRADIO_PID=$!
-echo "Gradio запущен, PID=$GRADIO_PID"
 
-echo "Чтобы остановить: kill $MCP_PID $GRADIO_PID"
+echo "Сервисы запущены: vLLM PID=$VLLM_PID, MCP PID=$MCP_PID, Gradio PID=$GRADIO_PID"
+echo "Чтобы остановить: kill $VLLM_PID $MCP_PID $GRADIO_PID"


### PR DESCRIPTION
## Summary
- handle existing processes and launch all components
- maintain chat history between exchanges

## Testing
- `python -m py_compile orchestrator.py gradio_app.py mcp_server.py onec_client.py client.py connection_test.py`
- `bash -n start_MCP.sh`


------
https://chatgpt.com/codex/tasks/task_e_688fcdebbbfc8328bd24f123be571855