### PR TITLE
Add Docker setup for MCP app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+*.pyo
+*.log
+logs/
+.git
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1
+
+# System dependencies for pdf2image and Tesseract OCR
+RUN apt-get update && apt-get install -y \
+    tesseract-ocr tesseract-ocr-rus poppler-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 7860 9000
+
+CMD ["python", "gradio_app.py"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install -r requirements.txt
 python MCP_1C/mcp_server.py
 ```
 
-The MCP API will be available on port 8000 by default. Clients can connect to `/hs/mcp/` on your 1C server to invoke the tools exposed by MCP.
+The MCP API will be available on port 9000 by default. Clients can connect to `/hs/mcp/` on your 1C server to invoke the tools exposed by MCP.
 
 ### Example request
 
@@ -43,9 +43,37 @@ Once the server is running you can call the demo endpoints from another
 terminal:
 
 ```bash
-curl http://localhost:8000/1c/plan_accounts
+curl http://localhost:9000/1c/plan_accounts
 ```
 
 This returns a JSON list of account objects. Similar requests can be sent to
 `/1c/turnover` with query parameters `account`, `periodStart` and `periodEnd`.
+
+## Running with Docker
+
+The repository includes a `Dockerfile` and `docker-compose.yml` for a fully
+containerised setup. By default the stack launches three services:
+
+- **mcp-server** – FastAPI service exposing the MCP tools.
+- **gradio-app** – web UI for interacting with the orchestrator.
+- **llm** – optional vLLM server used by the orchestrator (can be disabled by
+  removing it from the Compose file).
+
+Start everything with:
+
+```bash
+docker compose up --build
+```
+
+Default ports are `9000` for the MCP server, `7860` for the Gradio UI and `8000`
+for the LLM service. If any port is busy you can override them via environment
+variables:
+
+```bash
+MCP_PORT=9100 GRADIO_PORT=7861 LLM_PORT=8001 docker compose up --build
+```
+
+The Gradio interface will then be available at
+`http://localhost:${GRADIO_PORT}`. Set `MCP_1C_BASE`, `ONEC_USERNAME` and
+`ONEC_PASSWORD` to connect to a real 1C instance.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.9"
+
+services:
+  mcp-server:
+    build: .
+    command: uvicorn mcp_server:app --host 0.0.0.0 --port ${MCP_PORT:-9000}
+    environment:
+      MCP_1C_BASE: ${MCP_1C_BASE:-}
+      ONEC_USERNAME: ${ONEC_USERNAME:-}
+      ONEC_PASSWORD: ${ONEC_PASSWORD:-}
+    ports:
+      - "${MCP_PORT:-9000}:${MCP_PORT:-9000}"
+
+  gradio-app:
+    build: .
+    command: python gradio_app.py
+    environment:
+      MCP_URL: http://mcp-server:${MCP_PORT:-9000}
+      GRADIO_PORT: ${GRADIO_PORT:-7860}
+      LLM_URL: ${LLM_URL:-http://llm:8000/v1}
+    ports:
+      - "${GRADIO_PORT:-7860}:${GRADIO_PORT:-7860}"
+    depends_on:
+      - mcp-server
+
+  llm:
+    image: vllm/vllm-openai:latest
+    command: --model ${MODEL:-Salesforce/xLAM-2-32b-fc-r}
+    ports:
+      - "${LLM_PORT:-8000}:8000"

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -30,19 +30,23 @@ async def chat_fn(message: str, history: list, file: Optional[str]):
         formatted_history.append({"role": "user", "content": user_msg})
         formatted_history.append({"role": "assistant", "content": bot_msg})
 
-    async with SearchAgent(mcp_cmd=os.getenv('MCP_URL', 'http://localhost:9000')) as agent:
+    async with SearchAgent(
+        mcp_cmd=os.getenv("MCP_URL", "http://localhost:9000"),
+        llm_url=os.getenv("LLM_URL", "http://localhost:8000/v1"),
+    ) as agent:
         return await agent.ask(text, history=formatted_history)
 
 
 def main():
+    port = int(os.getenv("GRADIO_PORT", "7860"))
     with gr.Blocks() as demo:
         gr.Markdown("# Ассистент бухгалтера")
-        chatbot = gr.ChatInterface(
+        gr.ChatInterface(
             chat_fn,
-            additional_inputs=[gr.File(label='Документ')],
+            additional_inputs=[gr.File(label="Документ")],
             type="messages",
         )
-    demo.launch(server_name="0.0.0.0", server_port=7860)
+    demo.launch(server_name="0.0.0.0", server_port=port)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- containerize MCP server and Gradio interface with a reusable Python 3.12 image
- make Gradio and LLM endpoints configurable via environment variables
- document Docker usage and port overrides

## Testing
- `python -m py_compile gradio_app.py orchestrator.py mcp_server.py onec_client.py client.py connection_test.py`
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_68905a13fc40832895d346de387da257