### PR TITLE
Fix MCP endpoint path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     build: .
     command: python gradio_app.py
     environment:
-      MCP_URL: http://mcp-server:${MCP_PORT:-9003}
+      MCP_URL: http://mcp-server:${MCP_PORT:-9003}/mcp/
       GRADIO_PORT: ${GRADIO_PORT:-7860}
       LLM_SERVER_URL: ${LLM_SERVER_URL:-http://host.docker.internal:8000/v1}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-empty}

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -31,7 +31,7 @@ async def chat_fn(message: str, history: list, file: Optional[str]):
         formatted_history.append({"role": "assistant", "content": bot_msg})
 
     async with SearchAgent(
-        mcp_cmd=os.getenv("MCP_URL", "http://localhost:9000"),
+        mcp_cmd=os.getenv("MCP_URL", "http://localhost:9003/mcp/"),
         llm_url=os.getenv("LLM_SERVER_URL", "http://localhost:8000/v1"),
     ) as agent:
         return await agent.ask(text, history=formatted_history)


### PR DESCRIPTION
## Summary
- ensure SearchAgent connects to FastMCP server using `/mcp/` path
- update Docker compose to expose correct MCP endpoint

## Testing
- `python -m py_compile gradio_app.py orchestrator.py mcp_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6891d58b59d88328959ee3f9d49e3540