### PR TITLE
Fix FastMCP server startup and update tool handling

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -321,6 +321,10 @@ async def get_schema(object_name: str) -> Dict[str, Any]:
     return await asyncio.to_thread(_server.get_schema, object_name)
 
 
+# Expose ASGI application for uvicorn/ASGI servers.
+app = mcp.streamable_http_app()
+
+
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run("streamable-http")
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -89,12 +89,17 @@ class SearchAgent:
                 for call in msg.tool_calls:
                     args = json.loads(call.function.arguments)
                     result = await self.mcp.call_tool(call.function.name, args)
+                    output = (
+                        result.data
+                        if result.data is not None
+                        else (result.content[0].text if result.content else "")
+                    )
                     msgs.append({
                         "role": "tool",
                         "tool_call_id": call.id,
-                        "content": json.dumps(result[0].text)
+                        "content": json.dumps(output)
                     })
-                    print("function_called", result)
+                    print("function_called", output)
                 continue
             if '</Finished>' not in msg.content:
                 msgs.append(


### PR DESCRIPTION
## Summary
- expose FastMCP `streamable_http_app` as ASGI `app` so uvicorn can start the server
- run server with streamable-http transport when executed directly
- adapt `SearchAgent` to new `fastmcp` client `CallToolResult` API

## Testing
- `python -m py_compile mcp_server.py orchestrator.py gradio_app.py`
- `python - <<'PY'
import asyncio, anyio
from mcp_server import mcp
from fastmcp import Client

async def main():
    async with anyio.create_task_group() as tg:
        tg.start_soon(mcp.run_streamable_http_async)
        await anyio.sleep(0.5)
        async with Client("http://127.0.0.1:8000/mcp") as client:
            tools = await client.list_tools()
            print('tools', [t.name for t in tools])
        tg.cancel_scope.cancel()

asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6894effa49288328859cedac89ca8667