### PR TITLE
Add configurable debug logging

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,6 +1,11 @@
 import asyncio
 import os
+import logging
 from orchestrator import SearchAgent
+from log_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 
 async def main():
@@ -20,7 +25,7 @@ async def main():
         4) Language. Always deliver your replies in Russian.
         5) Completion tag. End every final answer with the tag </Finished> (either on a new line or directly after the text).
 """)
-        print(answer)
+        logger.info("Answer: %s", answer)
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/connection_test.py
+++ b/connection_test.py
@@ -1,5 +1,11 @@
 import requests
 from requests.auth import HTTPBasicAuth
+import logging
+
+from log_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 # === Connection parameters ===
 BASE_URL = "http://192.168.18.113/TEST19/odata/standard.odata/Catalog_Контрагенты?$format=json"
@@ -15,13 +21,12 @@ try:
         timeout=10
     )
 
-    print("Status code:", response.status_code)
+    logger.info("Status code: %s", response.status_code)
 
     if response.status_code == 200:
-        print("Server response:")
-        print(response.text)  # or response.json() if the response is JSON
+        logger.debug("Server response: %s", response.text)  # or response.json() if the response is JSON
     else:
-        print("Error:", response.text)
+        logger.error("Error: %s", response.text)
 
 except requests.exceptions.RequestException as e:
-    print("Connection error:", e)
+    logger.exception("Connection error: %s", e)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       MCP_1C_BASE: ${MCP_1C_BASE:-}
       ONEC_USERNAME: ${ONEC_USERNAME:-}
       ONEC_PASSWORD: ${ONEC_PASSWORD:-}
+      DEBUG: ${DEBUG:-false}
     ports:
       - "${MCP_PORT:-9003}:${MCP_PORT:-9003}"
     extra_hosts:
@@ -21,6 +22,7 @@ services:
       GRADIO_PORT: ${GRADIO_PORT:-7860}
       LLM_SERVER_URL: ${LLM_SERVER_URL:-http://host.docker.internal:8000/v1}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-empty}
+      DEBUG: ${DEBUG:-false}
     ports:
       - "${GRADIO_PORT:-7860}:${GRADIO_PORT:-7860}"
     depends_on:

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -5,8 +5,13 @@ import gradio as gr
 from PIL import Image
 from pdf2image import convert_from_path
 import pytesseract
+import logging
 
 from orchestrator import SearchAgent
+from log_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 # Число предыдущих сообщений диалога, которые передаются модели.
 # Можно задать через переменную окружения CHAT_HISTORY_TURNS.
@@ -32,9 +37,12 @@ async def chat_fn(message: str, history: list, file: Optional[str]):
         file:   Необязательный файл с документом, который необходимо распознать.
     """
 
+    logger.debug("Received message=%s file=%s", message, file)
     text = message
     if file:
-        text += "\n" + extract_text(file)
+        extracted = extract_text(file)
+        logger.debug("Extracted text from file: %s", extracted)
+        text += "\n" + extracted
 
     # Ограничиваем длину истории, чтобы не переполнять контекст окна модели.
     trimmed_history = history[-MAX_TURNS * 2:] if MAX_TURNS > 0 else history
@@ -53,7 +61,10 @@ async def chat_fn(message: str, history: list, file: Optional[str]):
         mcp_cmd=os.getenv("MCP_URL", "http://localhost:9003/mcp/"),
         llm_url=os.getenv("LLM_SERVER_URL", "http://localhost:8000/v1"),
     ) as agent:
-        return await agent.ask(text, history=formatted_history)
+        logger.debug("Sending text to agent: %s", text)
+        response = await agent.ask(text, history=formatted_history)
+        logger.debug("Agent response: %s", response)
+        return response
 
 
 def main():

--- a/log_config.py
+++ b/log_config.py
@@ -1,0 +1,15 @@
+import logging
+import os
+
+
+def setup_logging() -> None:
+    """Configure application-wide logging based on DEBUG env variable."""
+    if getattr(setup_logging, "_configured", False):
+        return
+    debug = os.getenv("DEBUG", "false").lower() in {"1", "true", "yes"}
+    level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    setup_logging._configured = True

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -15,9 +15,14 @@ import os
 import json
 import re
 from typing import Any, Dict, List, Optional, Union
+import logging
 
 from mcp.server.fastmcp import FastMCP
 from odata_client import ODataClient, _is_guid
+from log_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 
 class MCPServer:
@@ -253,7 +258,10 @@ async def list_objects(
     expand: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Return a list of entities from the specified entity set."""
-    return await asyncio.to_thread(_server.list_objects, object_name, filters, top, expand)
+    logger.debug("list_objects called with object_name=%s filters=%s top=%s expand=%s", object_name, filters, top, expand)
+    result = await asyncio.to_thread(_server.list_objects, object_name, filters, top, expand)
+    logger.debug("list_objects result: %s", result)
+    return result
 
 
 @mcp.tool()
@@ -263,7 +271,10 @@ async def find_object(
     expand: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Return the first entity matching the filter from the specified entity set."""
-    return await asyncio.to_thread(_server.find_object, object_name, filters, expand)
+    logger.debug("find_object called with object_name=%s filters=%s expand=%s", object_name, filters, expand)
+    result = await asyncio.to_thread(_server.find_object, object_name, filters, expand)
+    logger.debug("find_object result: %s", result)
+    return result
 
 
 @mcp.tool()
@@ -273,7 +284,10 @@ async def create_object(
     expand: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create a new entity in the specified entity set."""
-    return await asyncio.to_thread(_server.create_object, object_name, data, expand)
+    logger.debug("create_object called with object_name=%s data=%s expand=%s", object_name, data, expand)
+    result = await asyncio.to_thread(_server.create_object, object_name, data, expand)
+    logger.debug("create_object result: %s", result)
+    return result
 
 
 @mcp.tool()
@@ -284,7 +298,10 @@ async def update_object(
     expand: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Update fields of an existing entity."""
-    return await asyncio.to_thread(_server.update_object, object_name, object_id, data, expand)
+    logger.debug("update_object called with object_name=%s object_id=%s data=%s expand=%s", object_name, object_id, data, expand)
+    result = await asyncio.to_thread(_server.update_object, object_name, object_id, data, expand)
+    logger.debug("update_object result: %s", result)
+    return result
 
 
 @mcp.tool()
@@ -294,7 +311,10 @@ async def delete_object(
     physical_delete: bool = False,
 ) -> Dict[str, Any]:
     """Delete an entity (logical by default)."""
-    return await asyncio.to_thread(_server.delete_object, object_name, object_id, physical_delete)
+    logger.debug("delete_object called with object_name=%s object_id=%s physical_delete=%s", object_name, object_id, physical_delete)
+    result = await asyncio.to_thread(_server.delete_object, object_name, object_id, physical_delete)
+    logger.debug("delete_object result: %s", result)
+    return result
 
 
 @mcp.tool()
@@ -303,7 +323,10 @@ async def post_document(
     object_id: Union[str, Dict[str, str]],
 ) -> Dict[str, Any]:
     """Conduct (post) a document."""
-    return await asyncio.to_thread(_server.post_document, object_name, object_id)
+    logger.debug("post_document called with object_name=%s object_id=%s", object_name, object_id)
+    result = await asyncio.to_thread(_server.post_document, object_name, object_id)
+    logger.debug("post_document result: %s", result)
+    return result
 
 
 @mcp.tool()
@@ -312,13 +335,19 @@ async def unpost_document(
     object_id: Union[str, Dict[str, str]],
 ) -> Dict[str, Any]:
     """Reverse a previously posted document."""
-    return await asyncio.to_thread(_server.unpost_document, object_name, object_id)
+    logger.debug("unpost_document called with object_name=%s object_id=%s", object_name, object_id)
+    result = await asyncio.to_thread(_server.unpost_document, object_name, object_id)
+    logger.debug("unpost_document result: %s", result)
+    return result
 
 
 @mcp.tool()
 async def get_schema(object_name: str) -> Dict[str, Any]:
     """Retrieve metadata (properties and types) for the specified entity set."""
-    return await asyncio.to_thread(_server.get_schema, object_name)
+    logger.debug("get_schema called with object_name=%s", object_name)
+    result = await asyncio.to_thread(_server.get_schema, object_name)
+    logger.debug("get_schema result: %s", result)
+    return result
 
 
 # Expose ASGI application for uvicorn/ASGI servers.

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,5 +1,5 @@
-"""
-SearchAgent объединяет vLLM-чат и MCP-инструменты.
+"""SearchAgent объединяет vLLM-чат и MCP-инструменты.
+
 Использование:
     async with SearchAgent("mcp_server.py") as bot:
         answer = await bot.ask("Привет, мир!")
@@ -9,10 +9,16 @@ import json, asyncio
 from typing import List, Dict
 from openai import AsyncOpenAI
 from fastmcp import Client as MCP
+import logging
+
+from log_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 
 def _mcp_to_openai(tools):
-    print(tools)
+    logger.debug("Available tools: %s", tools)
     return [{
         "type": "function",
         "function": {
@@ -52,15 +58,17 @@ class SearchAgent:
             history: List[Dict[str, str]] | None = None,
     ) -> str:
         """Отправляет один запрос LLM, автоматически обслуживая tool-calls."""
+        logger.debug("ask called with prompt=%s system=%s history=%s", prompt, system, history)
         msgs: List[Dict[str, str]] = []
         if system:
             msgs.append({"role": "system", "content": system})
         if history:
             msgs.extend(history)
         msgs.append({"role": "user", "content": prompt})
+        logger.debug("Initial messages: %s", msgs)
 
         while True:
-            resp = ''
+            resp = ""
             try:
                 resp = await self.llm.chat.completions.create(
                     model=self.model,
@@ -71,7 +79,9 @@ class SearchAgent:
                         "min_tokens": 5
                     }
                 )
+                logger.debug("LLM response: %s", resp)
             except Exception as e:
+                logger.exception("LLM request failed: %s", e)
                 id = msgs[-1]['tool_call_id']
                 content = msgs[-1]['content']
                 msgs.append({
@@ -88,22 +98,24 @@ class SearchAgent:
             if msg.tool_calls:
                 for call in msg.tool_calls:
                     args = json.loads(call.function.arguments)
+                    logger.debug("Calling tool %s with args %s", call.function.name, args)
                     result = await self.mcp.call_tool(call.function.name, args)
                     output = (
                         result.data
                         if result.data is not None
                         else (result.content[0].text if result.content else "")
                     )
+                    logger.debug("Tool %s returned %s", call.function.name, output)
                     msgs.append({
                         "role": "tool",
                         "tool_call_id": call.id,
                         "content": json.dumps(output)
                     })
-                    print("function_called", output)
                 continue
             if '</Finished>' not in msg.content:
                 msgs.append(
                     {"role": "user", "content": "Дай конечный результат с тегом </Finished>, "
                                                 "если ты закончил вызов инструментов."})
                 continue
+            logger.debug("Final response: %s", msg.content)
             return msg.content

--- a/vLLM/xlam_tool_call_parser.py
+++ b/vLLM/xlam_tool_call_parser.py
@@ -66,14 +66,14 @@ class xLAMToolParser(ToolParser):
         try:
             # Modified: Direct JSON parsing without looking for ```
             json_str = self.extract_first_json(model_output)
-            print('model_output', model_output)
+            logger.debug('model_output %s', model_output)
             if not json_str:
                 return ExtractedToolCallInformation(
                     tools_called=False,
                     tool_calls=[],
                     content=model_output
                 )
-            print('json_str', json_str)
+            logger.debug('json_str %s', json_str)
             obj = json.loads(json_str)
             tool_calls_data = obj if isinstance(obj, list) else [obj]
             tool_calls: List[ToolCall] = []
@@ -116,14 +116,14 @@ class xLAMToolParser(ToolParser):
         if current_text.endswith("]"):
             try:
                 json_str = self.extract_first_json(current_text)
-                print('model_output', current_text)
+                logger.debug('model_output %s', current_text)
                 if not json_str:
                     return ExtractedToolCallInformation(
                         tools_called=False,
                         tool_calls=[],
                         content=current_text
                     )
-                print('json_str', json_str)
+                logger.debug('json_str %s', json_str)
                 obj = json.loads(json_str)
                 tool_calls_data = obj if isinstance(obj, list) else [obj]
                 tool_calls: List[ToolCall] = []


### PR DESCRIPTION
## Summary
- add centralized logging setup toggled by DEBUG env var
- log user prompts, tool calls, and results across server and Gradio app
- expose DEBUG flag in docker-compose for runtime control

## Testing
- `python -m py_compile log_config.py orchestrator.py gradio_app.py mcp_server.py vLLM/xlam_tool_call_parser.py client.py connection_test.py`


------
https://chatgpt.com/codex/tasks/task_e_6895060f97248328855e6d37ff5d8533