### PR TITLE
Streamline logging to trace user requests

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -37,11 +37,10 @@ async def chat_fn(message: str, history: list, file: Optional[str]):
         file:   Необязательный файл с документом, который необходимо распознать.
     """
 
-    logger.debug("Received message=%s file=%s", message, file)
+    logger.info("User message: %s", message)
     text = message
     if file:
         extracted = extract_text(file)
-        logger.debug("Extracted text from file: %s", extracted)
         text += "\n" + extracted
 
     # Ограничиваем длину истории, чтобы не переполнять контекст окна модели.
@@ -61,9 +60,8 @@ async def chat_fn(message: str, history: list, file: Optional[str]):
         mcp_cmd=os.getenv("MCP_URL", "http://localhost:9003/mcp/"),
         llm_url=os.getenv("LLM_SERVER_URL", "http://localhost:8000/v1"),
     ) as agent:
-        logger.debug("Sending text to agent: %s", text)
         response = await agent.ask(text, history=formatted_history)
-        logger.debug("Agent response: %s", response)
+        logger.info("Agent response: %s", response)
         return response
 
 

--- a/log_config.py
+++ b/log_config.py
@@ -3,13 +3,20 @@ import os
 
 
 def setup_logging() -> None:
-    """Configure application-wide logging based on DEBUG env variable."""
+    """Configure application-wide logging and hide noisy third party loggers."""
     if getattr(setup_logging, "_configured", False):
         return
+
     debug = os.getenv("DEBUG", "false").lower() in {"1", "true", "yes"}
     level = logging.DEBUG if debug else logging.INFO
+
     logging.basicConfig(
         level=level,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
+
+    # Silence overly verbose libraries so we only log high level steps
+    for noisy in ("mcp.server", "mcp.client", "sse_starlette", "httpx"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
     setup_logging._configured = True

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -58,14 +58,13 @@ class SearchAgent:
             history: List[Dict[str, str]] | None = None,
     ) -> str:
         """Отправляет один запрос LLM, автоматически обслуживая tool-calls."""
-        logger.debug("ask called with prompt=%s system=%s history=%s", prompt, system, history)
+        logger.info("User prompt: %s", prompt)
         msgs: List[Dict[str, str]] = []
         if system:
             msgs.append({"role": "system", "content": system})
         if history:
             msgs.extend(history)
         msgs.append({"role": "user", "content": prompt})
-        logger.debug("Initial messages: %s", msgs)
 
         while True:
             resp = ""
@@ -79,7 +78,6 @@ class SearchAgent:
                         "min_tokens": 5
                     }
                 )
-                logger.debug("LLM response: %s", resp)
             except Exception as e:
                 logger.exception("LLM request failed: %s", e)
                 id = msgs[-1]['tool_call_id']
@@ -98,14 +96,14 @@ class SearchAgent:
             if msg.tool_calls:
                 for call in msg.tool_calls:
                     args = json.loads(call.function.arguments)
-                    logger.debug("Calling tool %s with args %s", call.function.name, args)
+                    logger.info("Calling tool %s with args %s", call.function.name, args)
                     result = await self.mcp.call_tool(call.function.name, args)
                     output = (
                         result.data
                         if result.data is not None
                         else (result.content[0].text if result.content else "")
                     )
-                    logger.debug("Tool %s returned %s", call.function.name, output)
+                    logger.info("Tool %s returned %s", call.function.name, output)
                     msgs.append({
                         "role": "tool",
                         "tool_call_id": call.id,
@@ -117,5 +115,5 @@ class SearchAgent:
                     {"role": "user", "content": "Дай конечный результат с тегом </Finished>, "
                                                 "если ты закончил вызов инструментов."})
                 continue
-            logger.debug("Final response: %s", msg.content)
+            logger.info("Final response: %s", msg.content)
             return msg.content


### PR DESCRIPTION
## Summary
- silence noisy third-party loggers and keep root level configurable
- log user prompts, tool calls, and final answers in SearchAgent
- report user messages and agent replies in Gradio chat handler

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68951320cd2083289a760c7def2ae960